### PR TITLE
Add optional :expires_after option when defining tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .bundle/
 coverage
 log/*.log

--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ simple_task:
   class: "SomeActiveJob"
   every: "2.minutes"
 
-# Runs once every day at 4:00 AM
+# Runs once every day at 4:00 AM. The job will expire after 23 hours, which means the
+# job will not run if 23 hours passes (server downtime) before the job is actually run
 overnight_task:
   class: "SomeSidekiqWorker"
   every: "1.day"
   at: "4:00"
+  expires_after: "23.hours"
 
 # Runs once every hour at the half hour
 half_hour_task:
@@ -97,12 +99,12 @@ on the `perform` method.
 
 How frequently the task should be performed as an ActiveSupport duration definition.
 
-```ruby
-1.day
-5.days
-12.hours
-20.minutes
-1.week
+```yml
+"1.day"
+"5.days"
+"12.hours"
+"20.minutes"
+"1.week"
 ```
 
 #### :at (optional)
@@ -113,13 +115,27 @@ follow the `every` duration to determine future execution times.
 
 Valid string formats/examples:
 
+```yml
+"18:00"
+"3:30"
+"**:00"
+"*:30"
+"Sun 2:00"
+"[Sun|Mon|Tue|Wed|Thu|Fri|Sat] 00:00"
 ```
-18:00
- 3:30
-**:00
- *:30
-Sun 2:00
-[Sun|Mon|Tue|Wed|Thu|Fri|Sat] 00:00
+
+#### :expires_after (optional)
+
+If your worker process is down for an extended period of time, you may not want jobs
+to fire when the server comes back online. By specifying an `expires_after` value, your
+job will not fire if the time the job actually runs later, by the specified duration,
+than the scheduled run time.
+
+The string should be in the form of an ActiveSupport duration.
+
+```yml
+"59.minutes"
+"23.hours"
 ```
 
 ## Writing Your Jobs
@@ -130,11 +146,9 @@ use the scheduled time to know when it was supposed to run vs the current time.
 
 ```ruby
 class ExampleJob < ActiveJob::Base
-  # @param task_name [String] This is the key used in the YAML file to define the task
-  # @param time [Integer] The epoch time for when the job was scheduled to be run
-  def perform(task_name, time)
-    puts task_name
-    puts Time.at(time)
+  # @param scheduled_time [Time] The time the job was scheduled to be run
+  def perform(scheduled_time)
+    puts scheduled_time.strftime("%a %F @ %I:%M:%S.%L %p")
   end
 end
 ```
@@ -166,10 +180,10 @@ even if one of the two was executed during the 10 minute scheduler wait time.
 
 ### Server Downtime Example
 
-If you're using a gem like [clockwork](https://github.com/Rykian/clockwork), there is no way for the clock process to
-know that the task was never run. If your task is scheduled for `12:00:00`, your
-clock process could possibly be restarted at `11:59:59` and your dyno might not
-be available until `12:00:20`.
+If you're using a gem like [clockwork](https://github.com/Rykian/clockwork),
+there is no way for the clock process to know that the task was never run.
+If your task is scheduled for `12:00:00`, your clock process could possibly
+be restarted at `11:59:59` and your dyno might not be available until `12:00:20`.
 
 Simple Scheduler would have already enqueued the task hours before the task should actually
 run, so you still have to worry about the worker dyno restarting, but when the worker
@@ -189,6 +203,7 @@ daily_digest_task:
   class: "DailyDigestEmailJob"
   every: "15.minutes"
   at: "*:00"
+  expires_after: "23.hours"
 ```
 
 app/jobs/daily_digest_email_job.rb:
@@ -199,12 +214,11 @@ class DailyDigestEmailJob < ApplicationJob
 
   # Called by Simple Scheduler and is given the scheduled time so decisions can be made
   # based on when the job was scheduled to be run rather than when it was actually run.
-  # @param task_name [String] This is the key used in the YAML file to define the task
-  # @param time [Integer] The epoch time for when the job was scheduled to be run
-  def perform(task_name, time)
+  # @param scheduled_time [Time] The time the job was scheduled to be run
+  def perform(scheduled_time)
     # Don't do this! This will be way too slow!
     User.find_each do |user|
-      if user.digest_time == Time.at(time)
+      if user.digest_time == scheduled_time
         DigestMailer.daily(user).deliver_later
       end
     end

--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Valid string formats/examples:
 #### :expires_after (optional)
 
 If your worker process is down for an extended period of time, you may not want jobs
-to fire when the server comes back online. By specifying an `expires_after` value, your
-job will not fire if the time the job actually runs later, by the specified duration,
-than the scheduled run time.
+to execute when the server comes back online. By specifying an `expires_after` value,
+your job will not fire if the time the job actually runs later, by the specified
+duration, than the scheduled run time.
 
 The string should be in the form of an ActiveSupport duration.
 
@@ -140,9 +140,10 @@ The string should be in the form of an ActiveSupport duration.
 
 ## Writing Your Jobs
 
-Your Active Job or Sidekiq Worker must accept the task name and time stamp
-as arguments. This is so they can be queued properly and so your job can
-use the scheduled time to know when it was supposed to run vs the current time.
+There is no guarantee that the job will run at the exact time given in the
+configuration, so the time the job was scheduled to run will be passed to
+the job. This allows you to handle situations where the current time doesn't
+match the time it was expected to run. The `scheduled_time` argument is optional.
 
 ```ruby
 class ExampleJob < ActiveJob::Base
@@ -152,20 +153,6 @@ class ExampleJob < ActiveJob::Base
   end
 end
 ```
-
-When writing your jobs, you need to account for any possible server downtime.
-The most common downtime would be caused by Heroku's required daily restart.
-
-To ensure that your tasks always run, the jobs are queued in advance and it's
-possible the jobs may not be executed at the exact time that you configured
-them to run. If there is extended downtime, your jobs may back up and there
-is no guarantee of the order they will be executed when your worker process
-comes back online.
-
-Because there is no guarantee that the job is run at the exact time given in
-the configuration, the time the job was expected to run will be passed to
-the job so you can handle situations where the time it was run doesn't match
-the time it was expected to run.
 
 ### How It Works
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ use the scheduled time to know when it was supposed to run vs the current time.
 
 ```ruby
 class ExampleJob < ActiveJob::Base
-  # @param scheduled_time [Time] The time the job was scheduled to be run
+  # @param scheduled_time [Integer] The epoch time for when the job was scheduled to be run
   def perform(scheduled_time)
-    puts scheduled_time.strftime("%a %F @ %I:%M:%S.%L %p")
+    puts Time.at(scheduled_time)
   end
 end
 ```
@@ -214,11 +214,11 @@ class DailyDigestEmailJob < ApplicationJob
 
   # Called by Simple Scheduler and is given the scheduled time so decisions can be made
   # based on when the job was scheduled to be run rather than when it was actually run.
-  # @param scheduled_time [Time] The time the job was scheduled to be run
+  # @param scheduled_time [Integer] The epoch time for when the job was scheduled to be run
   def perform(scheduled_time)
     # Don't do this! This will be way too slow!
     User.find_each do |user|
-      if user.digest_time == scheduled_time
+      if user.digest_time == Time.at(scheduled_time)
         DigestMailer.daily(user).deliver_later
       end
     end

--- a/README.md
+++ b/README.md
@@ -154,7 +154,28 @@ class ExampleJob < ActiveJob::Base
 end
 ```
 
-### How It Works
+## Handling Expired Jobs
+
+If you assign the `expires_after` option to your task, you may want to know if
+a job wasn't run because it expires. Add this block to an initializer file:
+
+```ruby
+# config/initializers/simple_scheduler.rb
+
+# @param exception [SimpleScheduler::FutureJob::Expired]
+SimpleScheduler.expired_task do |exception|
+  ExceptionNotifier.notify_exception(
+    exception,
+    data: {
+      task:      exception.task.name,
+      scheduled: exception.scheduled_time,
+      actual:    exception.run_time
+    }
+  )
+end
+```
+
+## How It Works
 
 Once the rake task is added to Heroku Scheduler, the Simple Scheduler library
 will load the configuration file every 10 minutes, and ensure that each task

--- a/config/simple_scheduler.yml
+++ b/config/simple_scheduler.yml
@@ -1,10 +1,10 @@
 # Example file used by scheduler_job_spec.rb as the default config path.
 job_one:
-  class: "SimpleSchedulerTestJob"
+  class: "TestJob"
   every: "1.week"
   at: "Sun 1:00"
 
 job_two:
-  class: "SimpleSchedulerTestJob"
+  class: "TestJob"
   every: "1.week"
   at: "Sun 1:00"

--- a/lib/simple_scheduler.rb
+++ b/lib/simple_scheduler.rb
@@ -1,5 +1,6 @@
 require "active_job"
 require "sidekiq/api"
+require_relative "./simple_scheduler/future_job"
 require_relative "./simple_scheduler/railtie"
 require_relative "./simple_scheduler/scheduler_job"
 require_relative "./simple_scheduler/task"

--- a/lib/simple_scheduler.rb
+++ b/lib/simple_scheduler.rb
@@ -8,4 +8,24 @@ require_relative "./simple_scheduler/version"
 
 # Module for scheduling jobs at specific times using Sidekiq.
 module SimpleScheduler
+  # Used by a Rails initializer to handle expired tasks.
+  #   SimpleScheduler.expired_task do |exception|
+  #     ExceptionNotifier.notify_exception(
+  #       exception,
+  #       data: {
+  #         task:      exception.task.name,
+  #         scheduled: exception.scheduled_time,
+  #         actual:    exception.run_time
+  #       }
+  #     )
+  #   end
+  def self.expired_task(&block)
+    expired_task_blocks << block
+  end
+
+  # Blocks that should be called when a task doesn't run because it has expired.
+  # @return [Array]
+  def self.expired_task_blocks
+    @expired_task_blocks ||= []
+  end
 end

--- a/lib/simple_scheduler/future_job.rb
+++ b/lib/simple_scheduler/future_job.rb
@@ -1,0 +1,59 @@
+module SimpleScheduler
+  # Active Job class that wraps the scheduled job and determines if the job
+  # should still be run based on the scheduled time and when the job expires.
+  class FutureJob < ActiveJob::Base
+    # Perform the future job as defined by the task.
+    # @param task_params [Hash] The params from the scheduled task
+    # @param scheduled_time [Integer] The epoch time for when the job was scheduled to be run
+    def perform(task_params, scheduled_time)
+      @task = Task.new(task_params)
+      @scheduled_time = Time.at(scheduled_time).in_time_zone(@task.time_zone)
+      return if expired?
+
+      if @task.job_class.included_modules.include?(Sidekiq::Worker)
+        queue_sidekiq_worker
+      else
+        queue_active_job
+      end
+    end
+
+    # Returns whether or not the job has expired based on the time
+    # between the scheduled run time and the current time.
+    # @return [Boolean]
+    def expired?
+      return false if @task.expires_after.blank?
+      expire_duration.from_now(@scheduled_time) < Time.now.in_time_zone(@task.time_zone)
+    end
+
+    private
+
+    # The duration between the scheduled run time and actual run time that
+    # will cause the job to expire. Expired jobs will not be executed.
+    def expire_duration
+      split_duration = @task.expires_after.split(".")
+      duration = split_duration[0].to_i
+      duration_units = split_duration[1]
+      duration.send(duration_units)
+    end
+
+    # Queue the job for immediate execution using Active Job.
+    def queue_active_job
+      puts "QUEUE ACTIVE JOB"
+      puts @task.job_class.instance_method(:perform).arity
+      if @task.job_class.instance_method(:perform).arity > 0
+        @task.job_class.perform_later(@scheduled_time)
+      else
+        @task.job_class.perform_later
+      end
+    end
+
+    # Queue the job for immediate execution using Sidekiq.
+    def queue_sidekiq_worker
+      if @task.job_class.instance_method(:perform).arity > 0
+        @task.job_class.perform_async(@scheduled_time)
+      else
+        @task.job_class.perform_async
+      end
+    end
+  end
+end

--- a/lib/simple_scheduler/future_job.rb
+++ b/lib/simple_scheduler/future_job.rb
@@ -4,18 +4,14 @@ module SimpleScheduler
   class FutureJob < ActiveJob::Base
     # An error class that is raised if a job does not run because the run time is
     # too late when compared to the scheduled run time.
+    # @!attribute run_time
+    #   @return [Time] The actual run time
+    # @!attribute scheduled_time
+    #   @return [Time] The scheduled run time
+    # @!attribute task
+    #   @return [SimpleScheduler::Task] The expired task
     class Expired < StandardError
-      # @!attribute run_time
-      #   @return [Time] The actual run time
-      attr_accessor :run_time
-
-      # @!attribute scheduled_time
-      #   @return [Time] The scheduled run time
-      attr_accessor :scheduled_time
-
-      # @!attribute task
-      #   @return [SimpleScheduler::Task] The expired task
-      attr_accessor :task
+      attr_accessor :run_time, :scheduled_time, :task
     end
 
     rescue_from Expired, with: :handle_expired_task

--- a/lib/simple_scheduler/scheduler_job.rb
+++ b/lib/simple_scheduler/scheduler_job.rb
@@ -1,6 +1,16 @@
 module SimpleScheduler
   # Active Job class that queues jobs defined in the config file.
   class SchedulerJob < ActiveJob::Base
+    # Accepts a file path to read the scheduler configuration.
+    # @param config_path [String]
+    def perform(config_path = nil)
+      config_path ||= "config/simple_scheduler.yml"
+      load_config(config_path)
+      queue_future_jobs
+    end
+
+    private
+
     # Load the global scheduler config from the YAML file.
     # @param config_path [String]
     def load_config(config_path)
@@ -9,14 +19,6 @@ module SimpleScheduler
       @time_zone = @config["tz"] || Time.zone.tzinfo.name
       @config.delete("queue_ahead")
       @config.delete("tz")
-    end
-
-    # Accepts a file path to read the scheduler configuration.
-    # @param config_path [String]
-    def perform(config_path = nil)
-      config_path ||= "config/simple_scheduler.yml"
-      load_config(config_path)
-      queue_future_jobs
     end
 
     # Queue each of the future jobs into Sidekiq from the defined tasks.

--- a/lib/simple_scheduler/task.rb
+++ b/lib/simple_scheduler/task.rb
@@ -1,9 +1,28 @@
 module SimpleScheduler
   # Class for parsing each task in the scheduler config YAML file and returning
   # the values needed to schedule the task in the future.
+  #
+  # @!attribute [r] at
+  #   @return [String] The starting time for the interval
+  # @!attribute [r] expires_after
+  #   @return [String] The time between the scheduled and actual run time that should cause the job not to run
+  # @!attribute [r] frequency
+  #   @return [ActiveSupport::Duration] How often the job will be run
+  # @!attribute [r] job_class
+  #   @return [Class] The class of the job or worker
+  # @!attribute [r] job_class_name
+  #   @return [String] The class name of the job or worker
+  # @!attribute [r] name
+  #   @return [String] The name of the task as defined in the YAML config
+  # @!attribute [r] queue_ahead
+  #   @return [String] The name of the task as defined in the YAML config
+  # @!attribute [r] time_zone
+  #   @return [ActiveSupport::TimeZone] The time zone to use when parsing the `at` option
+  # @!attribute [r] params
+  #   @return [Hash] The params used to create the task
   class Task
-    attr_accessor :at, :expires_after, :frequency, :job_class, :job_class_name, :name, :queue_ahead, :time_zone
-    attr_reader :params
+    attr_reader :at, :expires_after, :frequency, :job_class, :job_class_name
+    attr_reader :name, :params, :queue_ahead, :time_zone
 
     AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|(\d{1,2})):(\d{1,2})/
     DAYS = %w(Sun Mon Tue Wed Thu Fri Sat).freeze

--- a/lib/simple_scheduler/task.rb
+++ b/lib/simple_scheduler/task.rb
@@ -2,24 +2,24 @@ module SimpleScheduler
   # Class for parsing each task in the scheduler config YAML file and returning
   # the values needed to schedule the task in the future.
   #
-  # @!attribute [r] at
+  # @!attribute at
   #   @return [String] The starting time for the interval
-  # @!attribute [r] expires_after
+  # @!attribute expires_after
   #   @return [String] The time between the scheduled and actual run time that should cause the job not to run
-  # @!attribute [r] frequency
+  # @!attribute frequency
   #   @return [ActiveSupport::Duration] How often the job will be run
   # @!attribute [r] job_class
   #   @return [Class] The class of the job or worker
   # @!attribute [r] job_class_name
   #   @return [String] The class name of the job or worker
-  # @!attribute [r] name
+  # @!attribute name
   #   @return [String] The name of the task as defined in the YAML config
-  # @!attribute [r] queue_ahead
-  #   @return [String] The name of the task as defined in the YAML config
-  # @!attribute [r] time_zone
-  #   @return [ActiveSupport::TimeZone] The time zone to use when parsing the `at` option
   # @!attribute [r] params
   #   @return [Hash] The params used to create the task
+  # @!attribute queue_ahead
+  #   @return [String] The name of the task as defined in the YAML config
+  # @!attribute time_zone
+  #   @return [ActiveSupport::TimeZone] The time zone to use when parsing the `at` option
   class Task
     attr_reader :at, :expires_after, :frequency, :job_class, :job_class_name
     attr_reader :name, :params, :queue_ahead, :time_zone

--- a/lib/simple_scheduler/task.rb
+++ b/lib/simple_scheduler/task.rb
@@ -2,7 +2,8 @@ module SimpleScheduler
   # Class for parsing each task in the scheduler config YAML file and returning
   # the values needed to schedule the task in the future.
   class Task
-    attr_accessor :at, :frequency, :job_class, :job_class_name, :name, :queue_ahead, :time_zone
+    attr_accessor :at, :expires_after, :frequency, :job_class, :job_class_name, :name, :queue_ahead, :time_zone
+    attr_reader :params
 
     AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|(\d{1,2})):(\d{1,2})/
     DAYS = %w(Sun Mon Tue Wed Thu Fri Sat).freeze
@@ -13,25 +14,30 @@ module SimpleScheduler
     # @option params [String] :class The class of the Active Job or Sidekiq Worker
     # @option params [String] :every How frequently the job will be performed
     # @option params [String] :at The starting time for the interval
+    # @option params [String] :expires_after The time between the scheduled and actual run time that should cause the job not to run
     # @option params [Integer] :queue_ahead The number of minutes that jobs should be queued in the future
     # @option params [String] :task_name The name of the task as defined in the YAML config
-    # @option params [ActiveSupport::TimeZone] :tz The time zone to use when parsing the `at` option
+    # @option params [String] :tz The time zone to use when parsing the `at` option
     def initialize(params)
       validate_params!(params)
-      @at = params[:at]
-      @frequency = parse_frequency(params[:every])
+      @at             = params[:at]
+      @expires_after  = params[:expires_after]
+      @frequency      = parse_frequency(params[:every])
       @job_class_name = params[:class]
-      @job_class = @job_class_name.constantize
-      @queue_ahead = params[:queue_ahead] || DEFAULT_QUEUE_AHEAD_MINUTES
-      @name = params[:name] || @job_class_name
-      @time_zone = params[:tz] || Time.zone
+      @job_class      = @job_class_name.constantize
+      @queue_ahead    = params[:queue_ahead] || DEFAULT_QUEUE_AHEAD_MINUTES
+      @name           = params[:name]
+      @params         = params
+      @time_zone      = params[:tz] ? ActiveSupport::TimeZone.new(params[:tz]) : Time.zone
     end
 
     # Returns an array of existing jobs matching the job class of the task.
     # @return [Array<Sidekiq::SortedEntry>]
     def existing_jobs
       @existing_jobs ||= SimpleScheduler::Task.scheduled_set.select do |job|
-        job.display_class == @job_class_name && job.display_args[0] == @name
+        next unless job.display_class == "SimpleScheduler::FutureJob"
+        task_params = job.display_args[0]
+        task_params[:class] == @job_class_name && task_params[:name] == @name
       end.to_a
     end
 
@@ -120,6 +126,7 @@ module SimpleScheduler
     end
 
     def validate_params!(params)
+      params[:name] ||= params[:class]
       raise ArgumentError, "Missing param `class` specifying the class of the job to run." unless params.key?(:class)
       raise ArgumentError, "Missing param `every` specifying how often the job should run." unless params.key?(:every)
     end

--- a/lib/simple_scheduler/version.rb
+++ b/lib/simple_scheduler/version.rb
@@ -1,3 +1,3 @@
 module SimpleScheduler
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/simple_scheduler.gemspec
+++ b/simple_scheduler.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "simplecov-rcov"
-  s.add_development_dependency "timecop"
 end

--- a/spec/dummy/app/jobs/simple_scheduler_test_job.rb
+++ b/spec/dummy/app/jobs/simple_scheduler_test_job.rb
@@ -1,4 +1,0 @@
-# Active Job for testing
-class SimpleSchedulerTestJob < ActiveJob::Base
-  def perform(time); end
-end

--- a/spec/dummy/app/jobs/simple_scheduler_test_job.rb
+++ b/spec/dummy/app/jobs/simple_scheduler_test_job.rb
@@ -1,0 +1,4 @@
+# Active Job for testing
+class SimpleSchedulerTestJob < ActiveJob::Base
+  def perform(time); end
+end

--- a/spec/dummy/app/jobs/simple_scheduler_test_worker.rb
+++ b/spec/dummy/app/jobs/simple_scheduler_test_worker.rb
@@ -1,0 +1,5 @@
+# Sidekiq Worker for testing
+class SimpleSchedulerTestWorker
+  include Sidekiq::Worker
+  def perform(time); end
+end

--- a/spec/dummy/app/jobs/test_job.rb
+++ b/spec/dummy/app/jobs/test_job.rb
@@ -1,0 +1,4 @@
+# Active Job for testing
+class TestJob < ApplicationJob
+  def perform(scheduled_time); end
+end

--- a/spec/dummy/app/jobs/test_no_args_job.rb
+++ b/spec/dummy/app/jobs/test_no_args_job.rb
@@ -1,0 +1,4 @@
+# Active Job for testing a job with no args
+class TestNoArgsJob < ApplicationJob
+  def perform; end
+end

--- a/spec/dummy/app/jobs/test_no_args_worker.rb
+++ b/spec/dummy/app/jobs/test_no_args_worker.rb
@@ -1,0 +1,5 @@
+# Sidekiq Worker for testing a worker with no args
+class TestNoArgsWorker
+  include Sidekiq::Worker
+  def perform; end
+end

--- a/spec/dummy/app/jobs/test_worker.rb
+++ b/spec/dummy/app/jobs/test_worker.rb
@@ -1,5 +1,5 @@
 # Sidekiq Worker for testing
-class SimpleSchedulerTestWorker
+class TestWorker
   include Sidekiq::Worker
-  def perform(time); end
+  def perform(scheduled_time); end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path("../../spec/dummy/config/environment.rb", __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "spec_helper"
 require "rspec/rails"
+require "sidekiq/testing"
 
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,9 +6,9 @@ require File.expand_path("../../spec/dummy/config/environment.rb", __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "spec_helper"
 require "rspec/rails"
-require "timecop"
 
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
+  config.include ActiveSupport::Testing::TimeHelpers
   config.filter_rails_from_backtrace!
 end

--- a/spec/simple_scheduler/config/active_job.yml
+++ b/spec/simple_scheduler/config/active_job.yml
@@ -1,4 +1,4 @@
 weekly_task:
-  class: "SimpleSchedulerTestJob"
+  class: "TestJob"
   every: "1.week"
   at: "Sun 1:00"

--- a/spec/simple_scheduler/config/hourly_task.yml
+++ b/spec/simple_scheduler/config/hourly_task.yml
@@ -1,4 +1,4 @@
 hourly_task:
-  class: "SimpleSchedulerTestJob"
+  class: "TestJob"
   every: "1.hour"
   at: "*:00"

--- a/spec/simple_scheduler/config/queue_ahead_global.yml
+++ b/spec/simple_scheduler/config/queue_ahead_global.yml
@@ -1,6 +1,6 @@
 queue_ahead: 120
 
 hourly_task:
-  class: "SimpleSchedulerTestJob"
+  class: "TestJob"
   every: "1.hour"
   at: "*:00"

--- a/spec/simple_scheduler/config/queue_ahead_per_task.yml
+++ b/spec/simple_scheduler/config/queue_ahead_per_task.yml
@@ -1,5 +1,5 @@
 hourly_task:
-  class: "SimpleSchedulerTestJob"
+  class: "TestJob"
   every: "1.hour"
   at: "*:00"
   queue_ahead: 180

--- a/spec/simple_scheduler/config/sidekiq_worker.yml
+++ b/spec/simple_scheduler/config/sidekiq_worker.yml
@@ -1,4 +1,4 @@
 weekly_task:
-  class: "SimpleSchedulerTestWorker"
+  class: "TestWorker"
   every: "1.week"
   at: "Sun 1:00"

--- a/spec/simple_scheduler/future_job_spec.rb
+++ b/spec/simple_scheduler/future_job_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+require "sidekiq/testing"
+Sidekiq::Testing.fake!
+
+describe SimpleScheduler::FutureJob, type: :job do
+  describe "successfully queues" do
+    subject(:job) { described_class.perform_later }
+
+    it "queues the job" do
+      expect { job }.to change(enqueued_jobs, :size).by(1)
+    end
+
+    it "is in default queue" do
+      expect(described_class.new.queue_name).to eq("default")
+    end
+  end
+
+  describe "when an Active Job is scheduled" do
+    let(:task_params) do
+      {
+        class: "SimpleSchedulerTestJob",
+        every: "1.hour",
+        name:  "job_task"
+      }
+    end
+
+    it "queues the Active Job" do
+      expect do
+        described_class.perform_now(task_params, Time.now.to_i)
+      end.to change(enqueued_jobs, :size).by(1)
+    end
+  end
+
+  describe "when a Sidekiq Worker is scheduled" do
+    let(:task_params) do
+      {
+        class: "SimpleSchedulerTestWorker",
+        every: "1.hour",
+        name:  "worker_task"
+      }
+    end
+
+    it "adds the job to the queue" do
+      expect do
+        described_class.perform_now(task_params, Time.now.to_i)
+      end.to change(SimpleSchedulerTestWorker.jobs, :size).by(1)
+    end
+  end
+
+  describe "when the job is run past the expired time" do
+    let(:task_params) do
+      {
+        class: "SimpleSchedulerTestJob",
+        every:         "1.hour",
+        name:          "job_task",
+        expires_after: "30.minutes"
+      }
+    end
+
+    it "doesn't queue the job" do
+      expect do
+        described_class.perform_now(task_params, (Time.now - 31.minutes).to_i)
+      end.to change(enqueued_jobs, :size).by(0)
+    end
+  end
+end

--- a/spec/simple_scheduler/future_job_spec.rb
+++ b/spec/simple_scheduler/future_job_spec.rb
@@ -47,7 +47,7 @@ describe SimpleScheduler::FutureJob, type: :job do
     end
   end
 
-  describe "when the job is run past the expired time" do
+  describe "when the job is run within the allowed expiration time" do
     let(:task_params) do
       {
         class: "SimpleSchedulerTestJob",
@@ -57,9 +57,26 @@ describe SimpleScheduler::FutureJob, type: :job do
       }
     end
 
-    it "doesn't queue the job" do
+    it "adds the job to the queue" do
       expect do
-        described_class.perform_now(task_params, (Time.now - 31.minutes).to_i)
+        described_class.perform_now(task_params, (Time.now - 29.minutes).to_i)
+      end.to change(enqueued_jobs, :size).by(1)
+    end
+  end
+
+  describe "when the job is run past the allowed expiration time" do
+    let(:task_params) do
+      {
+        class: "SimpleSchedulerTestJob",
+        every:         "1.hour",
+        name:          "job_task",
+        expires_after: "30.minutes"
+      }
+    end
+
+    it "doesn't add the job to the queue" do
+      expect do
+        described_class.perform_now(task_params, (Time.now - 30.minutes).to_i)
       end.to change(enqueued_jobs, :size).by(0)
     end
   end

--- a/spec/simple_scheduler/future_job_spec.rb
+++ b/spec/simple_scheduler/future_job_spec.rb
@@ -76,7 +76,7 @@ describe SimpleScheduler::FutureJob, type: :job do
 
     it "doesn't add the job to the queue" do
       expect do
-        described_class.perform_now(task_params, (Time.now - 30.minutes).to_i)
+        described_class.perform_now(task_params, (Time.now - 31.minutes).to_i)
       end.to change(enqueued_jobs, :size).by(0)
     end
   end

--- a/spec/simple_scheduler/future_job_spec.rb
+++ b/spec/simple_scheduler/future_job_spec.rb
@@ -1,6 +1,4 @@
 require "rails_helper"
-require "sidekiq/testing"
-Sidekiq::Testing.fake!
 
 describe SimpleScheduler::FutureJob, type: :job do
   describe "successfully queues" do

--- a/spec/simple_scheduler/scheduler_job_spec.rb
+++ b/spec/simple_scheduler/scheduler_job_spec.rb
@@ -5,13 +5,13 @@ Sidekiq::Testing.fake!
 describe SimpleScheduler::SchedulerJob, type: :job do
   # Active Job for testing
   class SimpleSchedulerTestJob < ActiveJob::Base
-    def perform(task_name, time); end
+    def perform(time); end
   end
 
   # Sidekiq Worker for testing
   class SimpleSchedulerTestWorker
     include Sidekiq::Worker
-    def perform(task_name, time); end
+    def perform(time); end
   end
 
   describe "successfully queues" do
@@ -23,22 +23,6 @@ describe SimpleScheduler::SchedulerJob, type: :job do
 
     it "is in default queue" do
       expect(described_class.new.queue_name).to eq("default")
-    end
-  end
-
-  describe "scheduling tasks using an Active Job class" do
-    it "queues two future jobs for the single weekly task" do
-      expect do
-        described_class.perform_now("spec/simple_scheduler/config/active_job.yml")
-      end.to change(enqueued_jobs, :size).by(2)
-    end
-  end
-
-  describe "scheduling tasks using a Sidekiq::Worker class" do
-    it "queues two future jobs for the single weekly task" do
-      expect do
-        described_class.perform_now("spec/simple_scheduler/config/sidekiq_worker.yml")
-      end.to change(SimpleSchedulerTestWorker.jobs, :size).by(2)
     end
   end
 
@@ -67,6 +51,14 @@ describe SimpleScheduler::SchedulerJob, type: :job do
       expect do
         described_class.perform_now("spec/simple_scheduler/config/queue_ahead_per_task.yml")
       end.to change(enqueued_jobs, :size).by(4)
+    end
+  end
+
+  describe "scheduling a weekly task" do
+    it "always queues two future jobs" do
+      expect do
+        described_class.perform_now("spec/simple_scheduler/config/active_job.yml")
+      end.to change(enqueued_jobs, :size).by(2)
     end
   end
 end

--- a/spec/simple_scheduler/scheduler_job_spec.rb
+++ b/spec/simple_scheduler/scheduler_job_spec.rb
@@ -1,19 +1,6 @@
 require "rails_helper"
-require "sidekiq/testing"
-Sidekiq::Testing.fake!
 
 describe SimpleScheduler::SchedulerJob, type: :job do
-  # Active Job for testing
-  class SimpleSchedulerTestJob < ActiveJob::Base
-    def perform(time); end
-  end
-
-  # Sidekiq Worker for testing
-  class SimpleSchedulerTestWorker
-    include Sidekiq::Worker
-    def perform(time); end
-  end
-
   describe "successfully queues" do
     subject(:job) { described_class.perform_later }
 

--- a/spec/simple_scheduler/task_spec.rb
+++ b/spec/simple_scheduler/task_spec.rb
@@ -350,7 +350,7 @@ describe SimpleScheduler::Task, type: :model do
 
       it "uses queue_ahead to ensure jobs are queued into the future" do
         travel_to Time.parse("2016-12-01 20:00:00 CST") do
-          task.queue_ahead = 50_400 # 5 weeks
+          task.instance_variable_set(:@queue_ahead, 50_400) # 5 weeks
           expect(task.future_run_times).to eq([
             Time.parse("2016-12-02 0:00:00 CST"),
             Time.parse("2016-12-09 0:00:00 CST"),
@@ -385,7 +385,7 @@ describe SimpleScheduler::Task, type: :model do
 
       it "uses queue_ahead to ensure jobs are queued into the future" do
         travel_to Time.parse("2016-12-01 20:00:00 CST") do
-          task.queue_ahead = 10_080 # 1 week
+          task.instance_variable_set(:@queue_ahead, 10_080) # 1 week
           expect(task.future_run_times).to eq([
             Time.parse("2016-12-02 0:30:00 CST"),
             Time.parse("2016-12-03 0:30:00 CST"),
@@ -422,7 +422,7 @@ describe SimpleScheduler::Task, type: :model do
 
       it "uses queue_ahead to ensure jobs are queued into the future" do
         travel_to Time.parse("2016-12-01 20:00:00 CST") do
-          task.queue_ahead = 360 # 6 hours
+          task.instance_variable_set(:@queue_ahead, 360) # 6 hours
           expect(task.future_run_times).to eq([
             Time.parse("2016-12-01 20:00:00 CST"),
             Time.parse("2016-12-01 21:00:00 CST"),
@@ -458,7 +458,7 @@ describe SimpleScheduler::Task, type: :model do
 
       it "uses queue_ahead to ensure jobs are queued into the future" do
         travel_to Time.parse("2016-12-01 20:00:00 CST") do
-          task.queue_ahead = 60 # minutes
+          task.instance_variable_set(:@queue_ahead, 60) # minutes
           expect(task.future_run_times).to eq([
             Time.parse("2016-12-01 20:00:00 CST"),
             Time.parse("2016-12-01 20:15:00 CST"),


### PR DESCRIPTION
If your worker process is down for an extended period of time, you may not want jobs
to execute when the server comes back online. By specifying an `expires_after` value,
your job will not fire if the time the job actually runs later, by the specified
duration, than the scheduled run time.

```yml
# Runs once every day at 4:00 AM. The job will expire after 23 hours, which means the
# job will not run if 23 hours passes (server downtime) before the job is actually run
overnight_task:
  class: "SomeSidekiqWorker"
  every: "1.day"
  at: "4:00"
  expires_after: "23.hours"
```

If you assign the `expires_after` option to your task, you may want to know if
a job wasn't run because it expires. Add this block to an initializer file:

```ruby
# config/initializers/simple_scheduler.rb

# Block for handling an expired task from Simple Scheduler
# @param exception [SimpleScheduler::FutureJob::Expired]
# @see 
SimpleScheduler.expired_task do |exception|
  ExceptionNotifier.notify_exception(
    exception,
    data: {
      task:      exception.task.name,
      scheduled: exception.scheduled_time,
      actual:    exception.run_time
    }
  )
end
```