### PR TITLE
Add rake task for resetting the future jobs queue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,8 +12,7 @@ Metrics/LineLength:
     - "spec/simple_scheduler/task_spec.rb"
 
 Style/IndentArray:
-  Exclude:
-    - "spec/simple_scheduler/task_spec.rb"
+  Enabled: false
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ language: ruby
 rvm:
   - 2.2.6
   - 2.3.3
-  - 2.4.0
 
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ language: ruby
 rvm:
   - 2.2.6
   - 2.3.3
+  - 2.4.0
 
 services:
   - redis-server

--- a/README.md
+++ b/README.md
@@ -183,6 +183,31 @@ SimpleScheduler.expired_task do |exception|
 end
 ```
 
+## Making Changes to Configuration File
+
+Any changes made to the YAML configuration file will be picked up by Simple Scheduler
+the next time `rake simple_scheduler` is run. Depending on the changes, you may need
+to reset the current job queue.
+
+Reasons you may need to reset the job queue:
+
+- Renaming a job's class
+- Deleting a scheduled task
+- Changing the task's run time interval
+- Changing the day of the week the job is run
+
+A rake task exists to delete all existing scheduled jobs and queue them back up from scratch:
+
+```
+rake simple_scheduler:reset
+```
+
+If you're using a custom configuration file:
+
+```
+rake simple_scheduler:reset["config/simple_scheduler.staging.yml"]
+```
+
 ## How It Works
 
 The Heroku Scheduler must be set up to run `rake simple_scheduler` every 10 minutes.

--- a/lib/simple_scheduler/future_job.rb
+++ b/lib/simple_scheduler/future_job.rb
@@ -26,6 +26,13 @@ module SimpleScheduler
       queue_task
     end
 
+    # Delete all future jobs created by Simple Scheduler from the `Sidekiq::ScheduledSet`.
+    def self.delete_all
+      Task.scheduled_set.each do |job|
+        job.delete if job.display_class == "SimpleScheduler::FutureJob"
+      end
+    end
+
     private
 
     # The duration between the scheduled run time and actual run time that

--- a/lib/tasks/simple_scheduler_tasks.rake
+++ b/lib/tasks/simple_scheduler_tasks.rake
@@ -2,3 +2,11 @@ desc "Queue future jobs defined using Simple Scheduler"
 task :simple_scheduler, [:config_path] => [:environment] do |_, args|
   SimpleScheduler::SchedulerJob.perform_now(args[:config_path])
 end
+
+namespace :simple_scheduler do
+  desc "Delete existing scheduled jobs and queue them from scratch"
+  task :reset, [:config_path] => [:environment] do |_, args|
+    SimpleScheduler::FutureJob.delete_all
+    SimpleScheduler::SchedulerJob.perform_now(args[:config_path])
+  end
+end

--- a/simple_scheduler.gemspec
+++ b/simple_scheduler.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sidekiq", "~> 4.2"
   s.add_development_dependency "appraisal"
   s.add_development_dependency "codeclimate-test-reporter"
+  s.add_development_dependency "rainbow", "~> 2.1"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rubocop"
   s.add_development_dependency "simplecov"

--- a/simple_scheduler.gemspec
+++ b/simple_scheduler.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sidekiq", "~> 4.2"
   s.add_development_dependency "appraisal"
   s.add_development_dependency "codeclimate-test-reporter"
-  s.add_development_dependency "rainbow", "~> 2.1"
+  s.add_development_dependency "rainbow", "~> 2.1.0"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rubocop"
   s.add_development_dependency "simplecov"

--- a/spec/simple_scheduler/scheduler_job_spec.rb
+++ b/spec/simple_scheduler/scheduler_job_spec.rb
@@ -17,9 +17,11 @@ describe SimpleScheduler::SchedulerJob, type: :job do
 
   describe "scheduling tasks without specifying a config path" do
     it "queues the jobs loaded from config/simple_scheduler.yml" do
-      expect do
-        described_class.perform_now
-      end.to change(enqueued_jobs, :size).by(4)
+      travel_to(now) do
+        expect do
+          described_class.perform_now
+        end.to change(enqueued_jobs, :size).by(4)
+      end
     end
   end
 

--- a/spec/simple_scheduler/scheduler_job_spec.rb
+++ b/spec/simple_scheduler/scheduler_job_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe SimpleScheduler::SchedulerJob, type: :job do
+  let(:now) { Time.parse("2017-01-27 00:00:00 CST") }
+
   describe "successfully queues" do
     subject(:job) { described_class.perform_later }
 
@@ -23,29 +25,37 @@ describe SimpleScheduler::SchedulerJob, type: :job do
 
   describe "scheduling an hourly task" do
     it "queues jobs for at least six hours into the future by default" do
-      expect do
-        described_class.perform_now("spec/simple_scheduler/config/hourly_task.yml")
-      end.to change(enqueued_jobs, :size).by(7)
+      travel_to(now) do
+        expect do
+          described_class.perform_now("spec/simple_scheduler/config/hourly_task.yml")
+        end.to change(enqueued_jobs, :size).by(7)
+      end
     end
 
     it "respects the queue_ahead global option" do
-      expect do
-        described_class.perform_now("spec/simple_scheduler/config/queue_ahead_global.yml")
-      end.to change(enqueued_jobs, :size).by(3)
+      travel_to(now) do
+        expect do
+          described_class.perform_now("spec/simple_scheduler/config/queue_ahead_global.yml")
+        end.to change(enqueued_jobs, :size).by(3)
+      end
     end
 
     it "respects the queue_ahead option per task" do
-      expect do
-        described_class.perform_now("spec/simple_scheduler/config/queue_ahead_per_task.yml")
-      end.to change(enqueued_jobs, :size).by(4)
+      travel_to(now) do
+        expect do
+          described_class.perform_now("spec/simple_scheduler/config/queue_ahead_per_task.yml")
+        end.to change(enqueued_jobs, :size).by(4)
+      end
     end
   end
 
   describe "scheduling a weekly task" do
     it "always queues two future jobs" do
-      expect do
-        described_class.perform_now("spec/simple_scheduler/config/active_job.yml")
-      end.to change(enqueued_jobs, :size).by(2)
+      travel_to(now) do
+        expect do
+          described_class.perform_now("spec/simple_scheduler/config/active_job.yml")
+        end.to change(enqueued_jobs, :size).by(2)
+      end
     end
   end
 end


### PR DESCRIPTION
The reset task is used to delete any existing jobs queued by Simple Scheduler and re-evaluating the configuration file to queue future jobs from scratch.

```
rake simple_scheduler:reset
```

You may need to reset the job queue if you make any of these changes to the configuration file:

- Renaming a job's class
- Deleting a scheduled task
- Changing the task's run time interval
- Changing the day of the week the job is run