### PR TITLE
Raise an error if an invalid run 'at' time is given

### DIFF
--- a/lib/simple_scheduler/at.rb
+++ b/lib/simple_scheduler/at.rb
@@ -12,6 +12,7 @@ module SimpleScheduler
     AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|((?:\b[0-1]?[0-9]|2[0-3]))):([0-5]\d)/
     DAYS = %w(Sun Mon Tue Wed Thu Fri Sat).freeze
 
+    # Error class raised when an invalid string is given for the time.
     class InvalidAtTime < StandardError; end
 
     # Accepts a time string to determine when a task should be run for the first time.

--- a/lib/simple_scheduler/at.rb
+++ b/lib/simple_scheduler/at.rb
@@ -9,7 +9,7 @@ module SimpleScheduler
   #   SimpleScheduler::At.new("Sun 0:00")
   #   # => 2016-12-11 00:00:00 -0600
   class At < Time
-    AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|(\d{1,2})):(\d{1,2})/
+    AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|((?:\b0?[0-9]|[0-1][0-9]|2[0-3]))):([0-5]\d)/
     DAYS = %w(Sun Mon Tue Wed Thu Fri Sat).freeze
 
     # Accepts a time string to determine when a task should be run for the first time.

--- a/lib/simple_scheduler/at.rb
+++ b/lib/simple_scheduler/at.rb
@@ -12,6 +12,8 @@ module SimpleScheduler
     AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|((?:\b[0-1]?[0-9]|2[0-3]))):([0-5]\d)/
     DAYS = %w(Sun Mon Tue Wed Thu Fri Sat).freeze
 
+    class InvalidAtTime < StandardError; end
+
     # Accepts a time string to determine when a task should be run for the first time.
     # Valid formats:
     #   "18:00"
@@ -45,7 +47,11 @@ module SimpleScheduler
     private
 
     def at_match
-      @at_match ||= AT_PATTERN.match(@at) || []
+      @at_match ||= begin
+        match = @at.nil? ? [] : AT_PATTERN.match(@at)
+        raise InvalidAtTime, "The `at` option '#{@at}' is invalid." if match.nil?
+        match
+      end
     end
 
     def at_hour

--- a/lib/simple_scheduler/at.rb
+++ b/lib/simple_scheduler/at.rb
@@ -13,7 +13,7 @@ module SimpleScheduler
     DAYS = %w(Sun Mon Tue Wed Thu Fri Sat).freeze
 
     # Error class raised when an invalid string is given for the time.
-    class InvalidAtTime < StandardError; end
+    class InvalidTime < StandardError; end
 
     # Accepts a time string to determine when a task should be run for the first time.
     # Valid formats:
@@ -50,7 +50,7 @@ module SimpleScheduler
     def at_match
       @at_match ||= begin
         match = @at.nil? ? [] : AT_PATTERN.match(@at)
-        raise InvalidAtTime, "The `at` option '#{@at}' is invalid." if match.nil?
+        raise InvalidTime, "The `at` option '#{@at}' is invalid." if match.nil?
         match
       end
     end

--- a/lib/simple_scheduler/at.rb
+++ b/lib/simple_scheduler/at.rb
@@ -9,7 +9,7 @@ module SimpleScheduler
   #   SimpleScheduler::At.new("Sun 0:00")
   #   # => 2016-12-11 00:00:00 -0600
   class At < Time
-    AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|((?:\b0?[0-9]|[0-1][0-9]|2[0-3]))):([0-5]\d)/
+    AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|((?:\b[0-1]?[0-9]|2[0-3]))):([0-5]\d)/
     DAYS = %w(Sun Mon Tue Wed Thu Fri Sat).freeze
 
     # Accepts a time string to determine when a task should be run for the first time.

--- a/spec/simple_scheduler/at_spec.rb
+++ b/spec/simple_scheduler/at_spec.rb
@@ -1,6 +1,36 @@
 require "rails_helper"
 
 describe SimpleScheduler::At, type: :model do
+  describe "AT_PATTERN" do
+    let(:pattern) { SimpleScheduler::At::AT_PATTERN }
+
+    it "matches valid times" do
+      match = pattern.match("0:00")
+      expect(match[2]).to eq("0")
+      expect(match[3]).to eq("00")
+
+      match = pattern.match("9:30")
+      expect(match[2]).to eq("9")
+      expect(match[3]).to eq("30")
+
+      match = pattern.match("Sat 23:59")
+      expect(match[2]).to eq("23")
+      expect(match[3]).to eq("59")
+
+      match = pattern.match("Sun 00:00")
+      expect(match[2]).to eq("00")
+      expect(match[3]).to eq("00")
+    end
+
+    it "doesn't match invalid times" do
+      expect(pattern.match("99:99")).to eq(nil)
+      expect(pattern.match("0:60")).to eq(nil)
+      expect(pattern.match("24:00")).to eq(nil)
+      expect(pattern.match("*:60")).to eq(nil)
+      expect(pattern.match("Sun 00:60")).to eq(nil)
+    end
+  end
+
   describe "when the run :at time includes a specific hour" do
     let(:at) { described_class.new("2:30", ActiveSupport::TimeZone.new("America/Chicago")) }
 

--- a/spec/simple_scheduler/at_spec.rb
+++ b/spec/simple_scheduler/at_spec.rb
@@ -148,4 +148,12 @@ describe SimpleScheduler::At, type: :model do
       end
     end
   end
+
+  describe "when the run :at time is invalid" do
+    it "raises an InvalidAtTime error" do
+      expect do
+        described_class.new("24:00", ActiveSupport::TimeZone.new("America/New_York"))
+      end.to raise_error(SimpleScheduler::At::InvalidAtTime, "The `at` option '24:00' is invalid.")
+    end
+  end
 end

--- a/spec/simple_scheduler/at_spec.rb
+++ b/spec/simple_scheduler/at_spec.rb
@@ -153,7 +153,7 @@ describe SimpleScheduler::At, type: :model do
     it "raises an InvalidAtTime error" do
       expect do
         described_class.new("24:00", ActiveSupport::TimeZone.new("America/New_York"))
-      end.to raise_error(SimpleScheduler::At::InvalidAtTime, "The `at` option '24:00' is invalid.")
+      end.to raise_error(SimpleScheduler::At::InvalidTime, "The `at` option '24:00' is invalid.")
     end
   end
 end

--- a/spec/simple_scheduler/at_spec.rb
+++ b/spec/simple_scheduler/at_spec.rb
@@ -25,6 +25,7 @@ describe SimpleScheduler::At, type: :model do
     it "doesn't match invalid times" do
       expect(pattern.match("99:99")).to eq(nil)
       expect(pattern.match("0:60")).to eq(nil)
+      expect(pattern.match("12:0")).to eq(nil)
       expect(pattern.match("24:00")).to eq(nil)
       expect(pattern.match("*:60")).to eq(nil)
       expect(pattern.match("Sun 00:60")).to eq(nil)


### PR DESCRIPTION
The `SimpleScheduler::At::AT_PATTERN` was updated to not allow invalid times, and now a `SimpleScheduler::At::InvalidTime` error is raised if an invalid time is given.

Hopefully this helps with odd errors seen in #13.