### PR TITLE
Add Beginning and End to :at Regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,7 @@ Valid string formats/examples:
 "3:30"
 "**:00"
 "*:30"
-"Sun 2:00"
-"[Sun|Mon|Tue|Wed|Thu|Fri|Sat] 00:00"
+"Sun 2:00" # [Sun|Mon|Tue|Wed|Thu|Fri|Sat]
 ```
 
 #### :expires_after (optional)

--- a/lib/simple_scheduler/at.rb
+++ b/lib/simple_scheduler/at.rb
@@ -9,7 +9,7 @@ module SimpleScheduler
   #   SimpleScheduler::At.new("Sun 0:00")
   #   # => 2016-12-11 00:00:00 -0600
   class At < Time
-    AT_PATTERN = /(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|((?:\b[0-1]?[0-9]|2[0-3]))):([0-5]\d)/
+    AT_PATTERN = /\A(Sun|Mon|Tue|Wed|Thu|Fri|Sat)?\s?(?:\*{1,2}|((?:\b[0-1]?[0-9]|2[0-3]))):([0-5]\d)\z/
     DAYS = %w(Sun Mon Tue Wed Thu Fri Sat).freeze
 
     # Error class raised when an invalid string is given for the time.

--- a/spec/simple_scheduler/at_spec.rb
+++ b/spec/simple_scheduler/at_spec.rb
@@ -29,6 +29,7 @@ describe SimpleScheduler::At, type: :model do
       expect(pattern.match("24:00")).to eq(nil)
       expect(pattern.match("*:60")).to eq(nil)
       expect(pattern.match("Sun 00:60")).to eq(nil)
+      expect(pattern.match("[Mon|Tue|Wed|Thu|Fri] 00:00")).to eq(nil)
     end
   end
 


### PR DESCRIPTION
This addresses https://github.com/simplymadeapps/simple_scheduler/issues/19 in that it makes the time regex more strict.  This will prevent `[Mon|Wed|Fri] 0:00` from passing validation and ignoring the days for the times, and instead render it invalid to prevent unexpected results. 