### PR TITLE
Run YML configuration file through ERB

### DIFF
--- a/lib/simple_scheduler/scheduler_job.rb
+++ b/lib/simple_scheduler/scheduler_job.rb
@@ -14,7 +14,7 @@ module SimpleScheduler
     # Load the global scheduler config from the YAML file.
     # @param config_path [String]
     def load_config(config_path)
-      @config = YAML.load_file(config_path)
+      @config = YAML.load(ERB.new(File.read(config_path)).result)
       @queue_ahead = @config["queue_ahead"] || Task::DEFAULT_QUEUE_AHEAD_MINUTES
       @time_zone = @config["tz"] || Time.zone.tzinfo.name
       @config.delete("queue_ahead")

--- a/spec/simple_scheduler/config/erb_test.yml
+++ b/spec/simple_scheduler/config/erb_test.yml
@@ -1,0 +1,1 @@
+<%= "test_job:\n  class: TestJob\n  every: 1.day\n  at: \"*:00\"" %>

--- a/spec/simple_scheduler/scheduler_job_spec.rb
+++ b/spec/simple_scheduler/scheduler_job_spec.rb
@@ -26,7 +26,7 @@ describe SimpleScheduler::SchedulerJob, type: :job do
   end
 
   describe "loading a YML file with ERB tags" do
-    it 'parses the file and queues the jobs' do
+    it "parses the file and queues the jobs" do
       travel_to(now) do
         expect do
           described_class.perform_now("spec/simple_scheduler/config/erb_test.yml")

--- a/spec/simple_scheduler/scheduler_job_spec.rb
+++ b/spec/simple_scheduler/scheduler_job_spec.rb
@@ -25,6 +25,16 @@ describe SimpleScheduler::SchedulerJob, type: :job do
     end
   end
 
+  describe "loading a YML file with ERB tags" do
+    it 'parses the file and queues the jobs' do
+      travel_to(now) do
+        expect do
+          described_class.perform_now("spec/simple_scheduler/config/erb_test.yml")
+        end.to change(enqueued_jobs, :size).by(2)
+      end
+    end
+  end
+
   describe "scheduling an hourly task" do
     it "queues jobs for at least six hours into the future by default" do
       travel_to(now) do


### PR DESCRIPTION
By processing the YAML file through erb this allows flexibility in building up the config files for different environments..   e.g. I could have a  simple_scheduler.common.yml that is included in the production.yml and staging.yml.
