### PR TITLE
Add support for Sidekiq 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,16 @@ after_success:
   - bundle exec codeclimate-test-reporter
 
 gemfile:
+  - gemfiles/latest.gemfile
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.gemfile
 
 language: ruby
 
 rvm:
-  - 2.2.6
-  - 2.3.3
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 
 services:
   - redis-server

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,14 @@
 appraise "rails-4" do
   gem "rails", "~> 4.2"
+  gem "sidekiq", "~> 4.2"
 end
 
 appraise "rails-5" do
   gem "rails", "~> 5.0"
+  gem "sidekiq", "~> 5.0"
+end
+
+appraise "latest" do
+  gem "rails"
+  gem "sidekiq"
 end

--- a/gemfiles/latest.gemfile
+++ b/gemfiles/latest.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0"
-gem "sidekiq", "~> 5.0"
+gem "rails"
+gem "sidekiq"
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2"
+gem "sidekiq", "~> 4.2"
 
 gemspec :path => "../"

--- a/simple_scheduler.gemspec
+++ b/simple_scheduler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", ">= 4.2"
-  s.add_dependency "sidekiq", "~> 4.2"
+  s.add_dependency "sidekiq", ">= 4.2"
   s.add_development_dependency "appraisal"
   s.add_development_dependency "codeclimate-test-reporter"
   s.add_development_dependency "rainbow", "~> 2.1.0"


### PR DESCRIPTION
I decided to require Sidekiq >= 4.2. I left it open ended so that if it works with every new version of Sidekiq, we won't have to update the gemspec again just to "add" support. We'll want to keep an eye on new versions of Rails and Sidekiq anyways, so I'm not too worried about supporting versions that haven't been released yet.

I updated the Travis CI environments. Tests now run against:

Ruby: 2.2.7, 2.3.4, 2.4.1
Rails: 4.2, 5.1+
Sidekiq: 4.2, 5.0+

Closes #31 