### PR TITLE
Allow custom Sidekiq queue name for FutureJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Create the file `config/simple_scheduler.yml` in your Rails project:
 ```yml
 # Global configuration options. These can also be set on each task.
 queue_ahead: 360 # Number of minutes to queue jobs into the future
+queue_name: "default" # The Sidekiq queue name used by SimpleScheduler::FutureJob
 tz: "America/Chicago" # The application time zone will be used by default if not set
 
 # Runs once every 2 minutes
@@ -96,10 +97,11 @@ rake simple_scheduler
 
 ![Heroku Scheduler](https://cloud.githubusercontent.com/assets/124570/21104523/6d733d1a-c04c-11e6-89af-590e7d234cdf.gif)
 
-It may be useful to point to a specific configuration file in non-production environments:
+It may be useful to point to a specific configuration file in non-production environments.
+Use a custom configuration file by setting the `SIMPLE_SCHEDULER_CONFIG` environment variable.
 
 ```
-rake simple_scheduler["config/simple_scheduler.staging.yml"]
+SIMPLE_SCHEDULER_CONFIG=config/simple_scheduler.staging.yml
 ```
 
 ### Task Options
@@ -285,12 +287,6 @@ A rake task exists to delete all existing scheduled jobs and queue them back up 
 
 ```
 rake simple_scheduler:reset
-```
-
-If you're using a custom configuration file:
-
-```
-rake simple_scheduler:reset["config/simple_scheduler.staging.yml"]
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ bundle
 Create the file `config/simple_scheduler.yml` in your Rails project:
 
 ```yml
-# Global configuration options. These can also be set on each task.
+# Global configuration options. The `queue_ahead` and `tz` options can also be set on each task.
 queue_ahead: 360 # Number of minutes to queue jobs into the future
 queue_name: "default" # The Sidekiq queue name used by SimpleScheduler::FutureJob
 tz: "America/Chicago" # The application time zone will be used by default if not set

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ You must be using:
 - Rails 4.2+
 - ActiveJob
 - [Sidekiq](http://sidekiq.org)
-- [Heroku Scheduler](https://elements.heroku.com/addons/scheduler)
+- [Heroku Scheduler](https://elements.heroku.com/addons/scheduler)*
 
 Both Active Job and Sidekiq::Worker classes can be queued by the scheduler.
+
+*\* Not actually required, but you're on your own for scheduling the `rake simple_scheduler` task to run every 10 minutes.*
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Reasons you may need to reset the job queue:
 - Deleting a scheduled task
 - Changing the task's run time interval
 - Changing the day of the week the job is run
+- Changing the `queue_name` in the config file
 
 A rake task exists to delete all existing scheduled jobs and queue them back up from scratch:
 

--- a/README.md
+++ b/README.md
@@ -262,9 +262,9 @@ SimpleScheduler.expired_task do |exception|
   ExceptionNotifier.notify_exception(
     exception,
     data: {
-      task:      exception.task.name,
+      task: exception.task.name,
       scheduled: exception.scheduled_time,
-      actual:    exception.run_time
+      actual: exception.run_time
     }
   )
 end

--- a/lib/tasks/simple_scheduler_tasks.rake
+++ b/lib/tasks/simple_scheduler_tasks.rake
@@ -1,12 +1,12 @@
 desc "Queue future jobs defined using Simple Scheduler"
-task :simple_scheduler, [:config_path] => [:environment] do |_, args|
-  SimpleScheduler::SchedulerJob.perform_now(args[:config_path])
+task simple_scheduler: :environment do
+  SimpleScheduler::SchedulerJob.perform_now
 end
 
 namespace :simple_scheduler do
   desc "Delete existing scheduled jobs and queue them from scratch"
-  task :reset, [:config_path] => [:environment] do |_, args|
+  task reset: :environment do
     SimpleScheduler::FutureJob.delete_all
-    SimpleScheduler::SchedulerJob.perform_now(args[:config_path])
+    SimpleScheduler::SchedulerJob.perform_now
   end
 end

--- a/spec/simple_scheduler/config/custom_queue_name.yml
+++ b/spec/simple_scheduler/config/custom_queue_name.yml
@@ -1,0 +1,6 @@
+queue_name: "custom"
+
+weekly_task:
+  class: "TestJob"
+  every: "1.week"
+  at: "Sun 1:00"

--- a/spec/simple_scheduler/scheduler_job_spec.rb
+++ b/spec/simple_scheduler/scheduler_job_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 describe SimpleScheduler::SchedulerJob, type: :job do
   let(:now) { Time.parse("2017-01-27 00:00:00 CST") }
 
+  # Set the environment variable for a custom YAML configuration file.
+  # @param path [String]
+  def config_path(path)
+    stub_const("ENV", ENV.to_hash.merge("SIMPLE_SCHEDULER_CONFIG" => path))
+  end
+
   describe "successfully queues" do
     subject(:job) { described_class.perform_later }
 
@@ -25,11 +31,29 @@ describe SimpleScheduler::SchedulerJob, type: :job do
     end
   end
 
+  describe "Sidekiq queue name" do
+    it "uses 'default' as the queue name if `queue_name` isn't set in the config" do
+      travel_to(now) do
+        described_class.perform_now
+        expect(enqueued_jobs.first[:queue]).to eq("default")
+      end
+    end
+
+    it "uses the custom queue name from the config file when adding FutureJob" do
+      config_path("spec/simple_scheduler/config/custom_queue_name.yml")
+      travel_to(now) do
+        described_class.perform_now
+        expect(enqueued_jobs.first[:queue]).to eq("custom")
+      end
+    end
+  end
+
   describe "loading a YML file with ERB tags" do
     it "parses the file and queues the jobs" do
+      config_path("spec/simple_scheduler/config/erb_test.yml")
       travel_to(now) do
         expect do
-          described_class.perform_now("spec/simple_scheduler/config/erb_test.yml")
+          described_class.perform_now
         end.to change(enqueued_jobs, :size).by(2)
       end
     end
@@ -37,25 +61,28 @@ describe SimpleScheduler::SchedulerJob, type: :job do
 
   describe "scheduling an hourly task" do
     it "queues jobs for at least six hours into the future by default" do
+      config_path("spec/simple_scheduler/config/hourly_task.yml")
       travel_to(now) do
         expect do
-          described_class.perform_now("spec/simple_scheduler/config/hourly_task.yml")
+          described_class.perform_now
         end.to change(enqueued_jobs, :size).by(7)
       end
     end
 
     it "respects the queue_ahead global option" do
+      config_path("spec/simple_scheduler/config/queue_ahead_global.yml")
       travel_to(now) do
         expect do
-          described_class.perform_now("spec/simple_scheduler/config/queue_ahead_global.yml")
+          described_class.perform_now
         end.to change(enqueued_jobs, :size).by(3)
       end
     end
 
     it "respects the queue_ahead option per task" do
+      config_path("spec/simple_scheduler/config/queue_ahead_per_task.yml")
       travel_to(now) do
         expect do
-          described_class.perform_now("spec/simple_scheduler/config/queue_ahead_per_task.yml")
+          described_class.perform_now
         end.to change(enqueued_jobs, :size).by(4)
       end
     end
@@ -63,9 +90,10 @@ describe SimpleScheduler::SchedulerJob, type: :job do
 
   describe "scheduling a weekly task" do
     it "always queues two future jobs" do
+      config_path("spec/simple_scheduler/config/active_job.yml")
       travel_to(now) do
         expect do
-          described_class.perform_now("spec/simple_scheduler/config/active_job.yml")
+          described_class.perform_now
         end.to change(enqueued_jobs, :size).by(2)
       end
     end


### PR DESCRIPTION
You can now specify the Sidekiq queue name used when queuing the FutureJob tasks:

```yml
# config/simple_scheduler.yml
queue_name: "some_custom_name" # The Sidekiq queue name used by SimpleScheduler::FutureJob
```

This also changes how a custom configuration file is loaded. Set the path to your custom configuration file using the SIMPLE_SCHEDULER_CONFIG environment variable:

```
SIMPLE_SCHEDULER_CONFIG=config/simple_scheduler.staging.yml
```

Closes #40 