### PR TITLE
add in support for specifying arguments to jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ weekly_task:
   every: "1.week"
   at: "Sat 0:00"
   tz: "America/New_York"
+
+# Runs once every week on Saturdays at 12:00 AM and passes 'my_arg' as the second arg to the job
+arg_task:
+  class: "ArgJob"
+  every: "1.week"
+  at: "Sat 0:00"
+  tz: "America/New_York"
+  arguments:
+    - "my_arg"
 ```
 
 ### Set up Heroku Scheduler
@@ -184,6 +193,20 @@ default in your Rails app will be used when parsing the `:at` time. A list of al
 timezone identifiers can be obtained using `TZInfo::Timezone.all_identifiers`.
 
 The `:tz` can be set as a global configuration option or for each individual task.
+
+#### :arguments (optional)
+
+User `:arguments` to specify an array of string arguments to pass to your job. This allows you to
+have one class handle multiple variations by passing in fixed arguments in the config. Your job must
+accept the first scheduled_time argument and these defined arguments will follow that.
+
+```ruby
+class ExampleJob < ActiveJob::Base
+  def perform(scheduled_time, custom_arg = nil)
+    # custom_arg will receive the first extra argument  
+  end
+end
+```
 
 ## Writing Your Jobs
 

--- a/config/simple_scheduler.yml
+++ b/config/simple_scheduler.yml
@@ -8,3 +8,10 @@ job_two:
   class: "TestJob"
   every: "1.week"
   at: "Sun 1:00"
+
+job_three:
+  class: "TestOptionalArgsJob"
+  every: "1.week"
+  at: "Sun 1:00"
+  arguments:
+    - "one"

--- a/lib/simple_scheduler/future_job.rb
+++ b/lib/simple_scheduler/future_job.rb
@@ -80,7 +80,7 @@ module SimpleScheduler
       if @task.job_class.instance_method(:perform).arity.zero?
         @task.job_class.send(perform_method)
       else
-        @task.job_class.send(perform_method, @scheduled_time.to_i)
+        @task.job_class.send(perform_method, @scheduled_time.to_i, *@task.job_arguments)
       end
     end
   end

--- a/lib/simple_scheduler/task.rb
+++ b/lib/simple_scheduler/task.rb
@@ -85,6 +85,12 @@ module SimpleScheduler
       @params[:class]
     end
 
+    # The extra job arguments (string only)
+    # @return [Array[String]]
+    def job_arguments
+      @params[:arguments] || []
+    end
+
     # The name of the task as defined in the YAML config.
     # @return [String]
     def name

--- a/spec/simple_scheduler/config/with_arguments.yml
+++ b/spec/simple_scheduler/config/with_arguments.yml
@@ -1,0 +1,6 @@
+with_args:
+  class: "TestOptionalArgsJob"
+  every: "1.week"
+  at: "Sun 1:00"
+  arguments:
+    - "one"

--- a/spec/simple_scheduler/scheduler_job_spec.rb
+++ b/spec/simple_scheduler/scheduler_job_spec.rb
@@ -26,7 +26,7 @@ describe SimpleScheduler::SchedulerJob, type: :job do
       travel_to(now) do
         expect do
           described_class.perform_now
-        end.to change(enqueued_jobs, :size).by(4)
+        end.to change(enqueued_jobs, :size).by(6)
       end
     end
   end
@@ -56,6 +56,27 @@ describe SimpleScheduler::SchedulerJob, type: :job do
           described_class.perform_now
         end.to change(enqueued_jobs, :size).by(2)
       end
+    end
+  end
+
+  describe 'scheduling a job with arguments' do
+    it 'queues the required jobs' do
+      config_path("spec/simple_scheduler/config/with_arguments.yml")
+      travel_to(now) do
+        expect do
+          described_class.perform_now
+        end.to change(enqueued_jobs, :size).by(2)
+      end
+    end
+
+    it 'queues the job with the arguments' do
+      config_path("spec/simple_scheduler/config/with_arguments.yml")
+      travel_to(now) do
+        described_class.perform_now
+      end
+
+      expect(enqueued_jobs.first[:args].first).to include('arguments' => ['one'])
+      puts enqueued_jobs
     end
   end
 


### PR DESCRIPTION
This adds the ability to specify fixed string arguments in the config.yml that are then passed to the job.

e.g. if I define a job like this
```ruby
class ExampleJob < ActiveJob::Base
  def perform(scheduled_time, arg = nil)
  end
end
```

and have a config like this
```yaml
my_job:
  class: "ExampleJob"
  every: "1.hour"
  arguments:
    - "some_arg"
```

Then when Simple Scheduler runs the job it will call it with the scheduled_time and the "some_arg".
```ruby
    ExampleJob.perform_later(Time.now.to_i, "some_arg")
```