### PR TITLE
Backfill scheduled jobs if they are missing within the queue ahead time

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ queue_ahead: 360 # Number of minutes to queue jobs into the future
 queue_name: "default" # The Sidekiq queue name used by SimpleScheduler::FutureJob
 tz: "America/Chicago" # The application time zone will be used by default if not set
 
-# Runs once every 2 minutes
+# Runs once every 2 minutes starting at the top of the hour
 simple_task:
   class: "SomeActiveJob"
   every: "2.minutes"
+  at: "*:00"
 
 # Runs once every day at 4:00 AM. The job will expire after 23 hours, which means the
 # job will not run if 23 hours passes (server downtime) before the job is actually run
@@ -126,11 +127,10 @@ How frequently the task should be performed as an ActiveSupport duration definit
 "1.week"
 ```
 
-#### :at (optional)
+#### :at
 
-This is the starting point\* for the `:every` duration. If not given, the job will
-run immediately when the configuration file is loaded for the first time and will
-follow the `:every` duration to determine future execution times.
+This is the starting point\* for the `:every` duration. This must be set so the expected
+run times in the future can be determined without duplicating jobs already in the queue.
 
 Valid string formats/examples:
 

--- a/lib/simple_scheduler/at.rb
+++ b/lib/simple_scheduler/at.rb
@@ -51,7 +51,8 @@ module SimpleScheduler
 
     def at_match
       @at_match ||= begin
-        match = @at.nil? ? [] : AT_PATTERN.match(@at)
+        match = AT_PATTERN.match(@at)
+        raise InvalidTime, "The `at` option is required." if @at.nil?
         raise InvalidTime, "The `at` option '#{@at}' is invalid." if match.nil?
 
         match

--- a/lib/simple_scheduler/scheduler_job.rb
+++ b/lib/simple_scheduler/scheduler_job.rb
@@ -29,8 +29,7 @@ module SimpleScheduler
     def queue_future_jobs
       tasks.each do |task|
         # Schedule the new run times using the future job wrapper.
-        new_run_times = task.future_run_times - task.existing_run_times
-        new_run_times.each do |time|
+        task.future_run_times.each do |time|
           SimpleScheduler::FutureJob.set(queue: @queue_name, wait_until: time)
                                     .perform_later(task.params, time.to_i)
         end

--- a/lib/simple_scheduler/task.rb
+++ b/lib/simple_scheduler/task.rb
@@ -65,17 +65,17 @@ module SimpleScheduler
     # @return [Array<Time>]
     # rubocop:disable Metrics/AbcSize
     def future_run_times
-      future_run_times = existing_run_times.dup
-      last_run_time = future_run_times.last || at - frequency
+      last_run_time = at - frequency
       last_run_time = last_run_time.in_time_zone(time_zone)
+      future_run_times = []
 
       # Ensure there are at least two future jobs scheduled and that the queue ahead time is filled
-      while future_run_times.length < 2 || minutes_queued_ahead(last_run_time) < queue_ahead
+      while (future_run_times + existing_run_times).length < 2 || minutes_queued_ahead(last_run_time) < queue_ahead
         last_run_time = frequency.from_now(last_run_time)
         # The hour may not match because of a shift caused by DST in previous run times,
         # so we need to ensure that the hour matches the specified hour if given.
         last_run_time = last_run_time.change(hour: at.hour, min: at.min) if at.hour?
-        future_run_times << last_run_time
+        future_run_times << last_run_time unless existing_run_times.include?(last_run_time)
       end
 
       future_run_times

--- a/spec/simple_scheduler/at_spec.rb
+++ b/spec/simple_scheduler/at_spec.rb
@@ -148,12 +148,10 @@ describe SimpleScheduler::At, type: :model do
   end
 
   describe "when the run :at time isn't given" do
-    let(:at) { described_class.new(nil, ActiveSupport::TimeZone.new("America/New_York")) }
-
-    it "returns the current time, but drops the seconds" do
-      travel_to Time.parse("2016-12-02 1:23:45 PST") do
-        expect(at).to eq(Time.parse("2016-12-02 1:23:00 PST"))
-      end
+    it "raises an InvalidAtTime error" do
+      expect do
+        described_class.new(nil, ActiveSupport::TimeZone.new("America/New_York"))
+      end.to raise_error(SimpleScheduler::At::InvalidTime, "The `at` option is required.")
     end
   end
 

--- a/spec/simple_scheduler/task_spec.rb
+++ b/spec/simple_scheduler/task_spec.rb
@@ -445,14 +445,13 @@ describe SimpleScheduler::Task, type: :model do
           class: "TestJob",
           every: "15.minutes",
           at: "*:00",
-          queue_ahead: 5,
+          queue_ahead: 60, # minutes
           tz: "America/Chicago"
         )
       end
 
       it "only returns the run times that need to be added to the queue" do
         travel_to Time.parse("2016-12-01 20:00:00 CST") do
-          task.instance_variable_set(:@queue_ahead, 60) # minutes
           expect(task).to receive(:existing_run_times).at_least(:once).and_return([
             Time.parse("2016-12-01 20:00:00 CST"),
             Time.parse("2016-12-01 20:15:00 CST"),
@@ -472,14 +471,13 @@ describe SimpleScheduler::Task, type: :model do
           class: "TestJob",
           every: "15.minutes",
           at: "*:00",
-          queue_ahead: 5,
+          queue_ahead: 60, # minutes
           tz: "America/Chicago"
         )
       end
 
       it "includes in the missing run time" do
         travel_to Time.parse("2016-12-01 20:00:00 CST") do
-          task.instance_variable_set(:@queue_ahead, 60) # minutes
           expect(task).to receive(:existing_run_times).at_least(:once).and_return([
             Time.parse("2016-12-01 20:00:00 CST"),
             # Time.parse("2016-12-01 20:15:00 CST"), <-- The missing run time


### PR DESCRIPTION
In an effort to make Simple Scheduler as bulletproof as possible, we are now backfilling future scheduled jobs that are missing from the queue.

Previously we were only scheduling jobs in the future based on the last run time of any scheduled jobs. This would be a problem if a job was accidentally deleted or if a job wasn't successfully enqueued followed by a later job being enqueued successfully.

This also makes the `:at` configuration option required. This is now required because we can no longer rely only on the last existing run time to determine when the next job will run now that we're backfilling the existing jobs.

### Previous behavior for scheduling a task that runs every 10 minutes:

Existing scheduled job times in Sidekiq:

```ruby
01:00:00
01:10:00
# 01:20:00 <-- missing
01:30:00
```

New times for the jobs added to the queue (assuming 60 min queue ahead time):

```ruby
01:40:00
01:50:00
02:00:00
```

### New behavior for scheduling a task that runs every 10 minutes:

Existing scheduled job times in Sidekiq:

```ruby
01:00:00
01:10:00
# 01:20:00 <-- missing
01:30:00
```

New times for the jobs added to the queue (assuming 60 min queue ahead time):

```ruby
01:20:00 # <-- backfilled
01:40:00
01:50:00
02:00:00
```