### PR TITLE
Release Version 1.1.0

### DIFF
--- a/lib/simple_scheduler/version.rb
+++ b/lib/simple_scheduler/version.rb
@@ -1,3 +1,3 @@
 module SimpleScheduler
-  VERSION = "1.0.0".freeze
+  VERSION = "1.1.0".freeze
 end


### PR DESCRIPTION
Release Notes:

## Enhancements

- Backfill scheduled jobs if they are missing within the queue ahead time #53

## Breaking Changes

The `:at` configuration option is now required. This is required because we can no longer rely only on the last existing run time to determine when the next job will run now that we're backfilling the existing jobs. 

If you previously were not setting the `:at` option, you will receive a `SimpleScheduler::At::InvalidTime` error if you upgrade to v1.1.0 without adding the configuration option to your simple_scheduler.yml file.