### PR TITLE
Lock SimpleCov version to be compatible with Code Climate coverage report

### DIFF
--- a/simple_scheduler.gemspec
+++ b/simple_scheduler.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rainbow"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rubocop", "~> 0.66.0"
-  s.add_development_dependency "simplecov"
+  s.add_development_dependency "simplecov", "< 0.18" # https://github.com/codeclimate/test-reporter/issues/413
   s.add_development_dependency "simplecov-rcov"
 end


### PR DESCRIPTION
We don't lock most of the dependences on purpose because the test suite runs on Travis CI every day so we can learn about incompatibilities with the latest versions by receiving a notification of a failed test run.

We were using SimpleCov < 0.18 when we first added the code coverage reporting, and then it broke because it was upgraded automatically. I don't think we need the latest version of SimpleCov at this time because of the maturity of Simple Scheduler.

Closes #61. I've subscribed to https://github.com/codeclimate/test-reporter/issues/413 to keep an eye on it.