### PR TITLE
FAF-250: Explicitly include the ActiveSupport assertions helpers

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require "sidekiq/testing"
 
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
+  config.include ActiveSupport::Testing::Assertions
   config.include ActiveSupport::Testing::TimeHelpers
   config.filter_rails_from_backtrace!
 end


### PR DESCRIPTION
Added `ActiveSupport::Testing::Assertions` to the included test helpers to ensure they are available for all Rails versions.