### PR TITLE
Limit dependencies to just be activejob

### DIFF
--- a/gemfiles/latest.gemfile
+++ b/gemfiles/latest.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails"
-gem "sidekiq"
+gem "activejob"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0"
+gem "activejob", "~> 5.0"
 gem "sidekiq", "~> 5.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0"
+gem "activejob", "~> 6.0"
 gem "sidekiq", "~> 6.0"
 
 gemspec path: "../"

--- a/simple_scheduler.gemspec
+++ b/simple_scheduler.gemspec
@@ -20,12 +20,15 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 5.0"
+  s.add_dependency "activejob", ">= 5.0"
   s.add_dependency "sidekiq", ">= 5.0"
+  s.add_development_dependency "actionmailer"
+  s.add_development_dependency "actionpack"
   s.add_development_dependency "appraisal"
   s.add_development_dependency "rainbow"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rubocop", "~> 0.66.0"
   s.add_development_dependency "simplecov", "< 0.18" # https://github.com/codeclimate/test-reporter/issues/413
   s.add_development_dependency "simplecov-rcov"
+  s.add_development_dependency "sprockets-rails"
 end


### PR DESCRIPTION
there is no need to force everyone to use all of rails to use this gem

This was brought on by the issue here ( https://twitter.com/nateberkopec/status/1374722404228853762 )

And since we are not using activestorage we could simply remove it, however this gem keeps pulling rails back in (when not needed)